### PR TITLE
Fix ancient tables

### DIFF
--- a/tables/ancient-languages-borger.utb
+++ b/tables/ancient-languages-borger.utb
@@ -93,6 +93,6 @@
 include cuneiform-transliterated.utb
 include grc-international-en-composed.utb
 include akk-borger.utb
-include hbo.utb
+include hbo-cantillated-rules.uti
 include syc.utb
 include uga.utb

--- a/tables/ancient-languages-us.utb
+++ b/tables/ancient-languages-us.utb
@@ -93,6 +93,6 @@
 include cuneiform-transliterated.utb
 include grc-international-en-composed.utb
 include akk.utb
-include hbo.utb
+include hbo-cantillated-rules.uti
 include syc.utb
 include uga.utb


### PR DESCRIPTION
The references in the ancient language studies tables were pointing at hbo.utb, therefore the behaviour of this table implicitly changed. I now included the cantillated uti and the tests pass again.